### PR TITLE
(rankCard) Fix error `ENOENT: no such file or directory`

### DIFF
--- a/src/rankCard.js
+++ b/src/rankCard.js
@@ -1,10 +1,10 @@
 const Discord = require('discord.js')
+const { join } = require('path');
 
 const Canvas = require('canvas')
 const { registerFont } = require('canvas')
-registerFont('./node_modules/simply-djs/src/Fonts/Poppins-SemiBold.ttf', { family: 'Poppins-Regular' })
-registerFont('./node_modules/simply-djs/src/Fonts/Poppins-SemiBold.ttf', { family: 'Poppins-Bold' })
-
+registerFont(join(__dirname,'Fonts', 'Poppins-SemiBold.ttf'), { family: 'Poppins-Regular' })
+registerFont(join(__dirname,'Fonts', 'Poppins-SemiBold.ttf'), { family: 'Poppins-Bold' })
 async function rankCard(client, message, options = []) {
 try {
     function shortener(count) {


### PR DESCRIPTION
Full Error:
````
Error: ENOENT: no such file or directory, lstat 'C:\Users\George Regnold\Documents\Greezy\node_modules\simply-djs'
    at Object.realpathSync (node:fs:1824:7)
    at registerFont (C:\Users\George Regnold\node_modules\canvas\index.js:48:34)
    at Object.<anonymous> (C:\Users\George Regnold\node_modules\simply-djs\src\rankCard.js:5:1)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Function.Module._load (node:internal/modules/cjs/loader:828:14)
    at Module.require (node:internal/modules/cjs/loader:1012:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at Object.<anonymous> (C:\Users\George Regnold\node_modules\simply-djs\simplydjs.js:8:27) {
  errno: -4058,
  syscall: 'lstat',
  code: 'ENOENT',
  path: 'C:\\Users\\George Regnold\\Documents\\Greezy\\node_modules\\simply-djs'
}
````

Because paths are relative to the directory where the main file was executed, you need to use the absolute path from the `src` folder instead by using `__dirname` and using `join` from the `path` module allows it to work on every OS.