### PR TITLE
(btnrole) Fix: `Cannot read property 'has' of undefined`

### DIFF
--- a/src/btnrole.js
+++ b/src/btnrole.js
@@ -6,7 +6,7 @@ async function btnrole(client, message, options = []) {
 
             let { MessageButton, MessageActionRow } = require('discord.js')
 
-            if (!message.author.permissions.has('ADMINISTRATOR')) return message.reply('You need `ADMINISTRATOR` permission to use this slash command')
+            if (!message.member.permissions.has('ADMINISTRATOR')) return message.reply('You need `ADMINISTRATOR` permission to use this slash command')
 
 
             let row = [];


### PR DESCRIPTION
The Error was found by `Om#7201` ([see here](https://discord.com/channels/867999056172052551/868005502397861919/884469656591667281)), the issue is using the `author` property which is a `User` which doesn't have Guild Permissions stored, so instead the `member` property should be used which has the `permissions` property.

> **Full Error:**
> ```Error Occurred | btnrole | . Error: TypeError r: Cannot read property 'has' of undefined```