### PR TITLE
fix winreroll.edit error in giveaways v13

### DIFF
--- a/src/clickBtn.js
+++ b/src/clickBtn.js
@@ -485,9 +485,9 @@ async function clickBtn(button, options = []) {
                 .setDescription(`🏆 Winner(s): ***${winnerNumber}***`)
                 .setFooter("Dm the host to claim your prize 0_0");
 
-              winreroll
-                .edit({
-                  content: `Congrats ${winboiz}. You just won the giveaway.`,
+              button.message.channel
+                .send({
+                  content: `Congrats ${winboiz}. You won the reroll for the giveaway.`,
                   embeds: [embb],
                   components: [ro]
                 })


### PR DESCRIPTION
fixed error on v13 giveaway reroll. 
![image](https://user-images.githubusercontent.com/68866924/135397636-8602004c-6f4b-4434-acdf-b6828b03fdd4.png)
