### PR TITLE
Use anonymous functions instead of `mathjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "dependencies": {
     "canvas": "^2.8.0",
-    "mathjs": "^9.4.4",
     "ms": "^2.1.3",
     "quickmongo": "^3.0.0",
     "rss-parser": "^3.12.0"

--- a/src/calc.js
+++ b/src/calc.js
@@ -1,5 +1,4 @@
 const Discord = require("discord.js");
-const math = require("mathjs");
 
 /**
  * @param {Discord.CommandInteraction} interaction
@@ -67,6 +66,7 @@ async function calculator(interaction, options = []) {
           components: row
         })
         .then(async (mssg) => {
+          /** @type {Discord.Message} */
           const msg = await interaction.fetchReply();
 
           let isWrong = false;
@@ -80,6 +80,8 @@ async function calculator(interaction, options = []) {
             const filter = (button) =>
               button.user.id === interaction.user.id &&
               button.customId === "cal" + val;
+
+            /** @type {Discord.InteractionCollector<Discord.ButtonInteraction>}*/
             let collect = msg.createMessageComponentCollector({
               filter,
               componentType: "BUTTON",
@@ -109,7 +111,7 @@ async function calculator(interaction, options = []) {
                   components: row
                 });
               } else if (value.includes("Delete"))
-                return interaction.deleteReply().catch(() => {});
+                return interaction.deleteReply().catch(() => { });
               else if (value.includes("Clear")) return (value = "0");
               emb1.setDescription("```" + value + "```");
               await msg.edit({
@@ -161,10 +163,13 @@ async function calculator(interaction, options = []) {
         return btn;
       }
 
+      const evalRegex = /^[0-9π+\-*\/\.\(\)]*$/
       function mathEval(input) {
         try {
-          let res = `${input} = ${math.evaluate(input.replace("π", math.pi))}`;
-          return res;
+          const matched = evalRegex.exec(input);
+          if (!matched) return "Wrong Input";
+
+          return `${input} = ${Function(`"use strict";let π=Math.PI;return (${input})`)()}`;
         } catch {
           return "Wrong Input";
         }
@@ -269,7 +274,7 @@ async function calculator(interaction, options = []) {
                 });
               } else if (value.includes("Delete")) {
                 msg.delete();
-                return interaction.delete().catch(() => {});
+                return interaction.delete().catch(() => { });
               } else if (value.includes("Clear")) return (value = "0");
               emb1.setDescription("```" + value + "```");
               await msg.edit({
@@ -321,10 +326,13 @@ async function calculator(interaction, options = []) {
         return btn;
       }
 
+      const evalRegex = /^[0-9π+\-*\/\.\(\)]*$/
       function mathEval(input) {
         try {
-          let res = `${input} = ${math.evaluate(input.replace("π", math.pi))}`;
-          return res;
+          const matched = evalRegex.exec(input);
+          if (!matched) return "Wrong Input";
+
+          return `${input} = ${Function(`"use strict";let π=Math.PI;return (${input})`)()}`;
         } catch {
           return "Wrong Input";
         }


### PR DESCRIPTION
Using anonymous Functions to calculate the mathematical expressions from the calculator makes the use of the [mathjs](https://www.npmjs.com/package/mathjs) library unnecessary because it is [huge](https://packagephobia.com/result?p=mathjs) and the calculator only uses one function of it so it's way more efficient to use the anonymous functions. For safety reasons, the mathematical expression is tested with a regular expression to prevent illegal characters that somehow got in there.