### PR TITLE
menuEmbed Fix

### DIFF
--- a/src/menuEmbed.js
+++ b/src/menuEmbed.js
@@ -108,7 +108,7 @@ async function dropdownPages(message, options = []) {
 			let selet = menu.values[0]
 
 			if (type === 2) {
-				if (message.author.id !== menu.user.id) return
+				if (message.user.id !== menu.user.id) return
 			}
 
 			if (selet === 'delete_menuemb') {


### PR DESCRIPTION
# Information
Slash commands didn't work because author isn't a property of [CommandInteraction](https://discord.js.org/#/docs/discord.js/stable/class/CommandInteraction).

# Checks
- [x] It works as intended :tada:
