### PR TITLE
Fixed every .setFooter() text object warning.

### DIFF
--- a/src/automeme.js
+++ b/src/automeme.js
@@ -83,7 +83,7 @@ async function automeme(client, options = []) {
 					.setURL(`${url}`)
 					.setImage(memeImage)
 					.setColor(options.embedColor || '#075FFF')
-					.setFooter(`🔺 ${upp} | Upvote Ratio: ${ratio}`)
+					.setFooter({ text: `🔺 ${upp} | Upvote Ratio: ${ratio}` })
 				channel.send({ embeds: [embed] })
 			})
 	}, interv)

--- a/src/bumpSys.js
+++ b/src/bumpSys.js
@@ -42,7 +42,7 @@ async function bumpSys(client, db, options = []) {
 								)
 								.setTimestamp()
 								.setColor('#06bf00')
-								.setFooter('Now its time to wait for 120 minutes. (2 hours)')
+								.setFooter({ text: 'Now its time to wait for 120 minutes. (2 hours)' })
 
 							message.channel.send({
 								content: options.content || '\u200b',
@@ -69,7 +69,7 @@ async function bumpSys(client, db, options = []) {
 							)
 							.setTimestamp()
 							.setColor('#075FFF')
-							.setFooter('Do !d bump to bump the server')
+							.setFooter({ text: 'Do !d bump to bump the server' })
 
 						cho.send({
 							content: options.content || '\u200b',

--- a/src/calc.js
+++ b/src/calc.js
@@ -63,7 +63,7 @@ async function calculator(interaction, options = []) {
 
 		const emb = new Discord.MessageEmbed()
 			.setColor(options.embedColor || 0x075fff)
-			.setFooter(foot)
+			.setFooter({ text: foot })
 			.setDescription('```0```')
 
 		let msg
@@ -86,7 +86,7 @@ async function calculator(interaction, options = []) {
 		let time = 600000
 		let value = ''
 		let emb1 = new Discord.MessageEmbed()
-			.setFooter(foot)
+			.setFooter({ text: foot })
 			.setColor(options.embedColor || 0x075fff)
 
 		function createCollector(val, result = false) {

--- a/src/clickBtn.js
+++ b/src/clickBtn.js
@@ -260,7 +260,7 @@ async function clickBtn(button, options = []) {
 								.setThumbnail(button.message.guild.iconURL())
 								.setTimestamp()
 								.setColor(options.embedColor || '#075FFF')
-								.setFooter(foot)
+								.setFooter({ text: foot })
 
 							if (options.embed) {
 								options.embed.description = options.embed.description
@@ -461,7 +461,7 @@ async function clickBtn(button, options = []) {
 					)
 					.setTimestamp()
 					.setColor('#c90000')
-					.setFooter(foot)
+					.setFooter({ text: foot })
 
 				button.followUp({
 					embeds: [options.confirmEmb || emb],
@@ -509,7 +509,7 @@ async function clickBtn(button, options = []) {
 						)
 						.setTimestamp()
 						.setColor('#cc0000')
-						.setFooter(foot)
+						.setFooter({ text: foot })
 
 					let ek = button.channel.name
 
@@ -595,7 +595,7 @@ async function clickBtn(button, options = []) {
 						.setDescription(
 							`Please wait.. We are Processing the winner with magiks`
 						)
-						.setFooter('Giveaway Ending.. Wait a moment.')
+						.setFooter({ text: 'Giveaway Ending.. Wait a moment.' })
 
 					setTimeout(() => {
 						button.message.edit({ embeds: [embeddd], components: [] })
@@ -658,7 +658,7 @@ async function clickBtn(button, options = []) {
 									{ name: '🏆 Winner(s):', value: `none` },
 									{ name: '💝 People Entered', value: `***${entero}***` }
 								)
-								.setFooter('Giveaway Ended.')
+								.setFooter({ text: 'Giveaway Ended.' })
 
 							let msgwonid = await db.get(
 								`giveaway_${button.message.id}_yaywon`
@@ -713,7 +713,7 @@ async function clickBtn(button, options = []) {
 									{ name: '🏆 Winner(s):', value: `${winner}` },
 									{ name: '💝 People Entered', value: `***${entero}***` }
 								)
-								.setFooter('Giveaway Ended.')
+								.setFooter({ text: 'Giveaway Ended.' })
 
 							let winmsgreroll = await db.get(
 								`giveaway_${button.message.id}_yaywon`
@@ -730,7 +730,7 @@ async function clickBtn(button, options = []) {
 								.setColor(0x3bb143)
 								.setTitle('You just won the giveaway.')
 								.setDescription(`🏆 Winner(s): ***${winnerNumber}***`)
-								.setFooter('Dm the host to claim your prize 0_0')
+								.setFooter({ text: 'Dm the host to claim your prize 0_0' })
 							if (!winreroll) {
 								button.channel
 									.send({
@@ -788,7 +788,7 @@ async function clickBtn(button, options = []) {
 						.setDescription(
 							`Please wait.. We are Processing the winner with magiks`
 						)
-						.setFooter('Giveaway Ending.. Wait a moment.')
+						.setFooter({ text: 'Giveaway Ending.. Wait a moment.' })
 
 					setTimeout(() => {
 						button.message.edit({ embeds: [embeddd], components: [] })
@@ -818,7 +818,7 @@ async function clickBtn(button, options = []) {
 									{ name: '🏆 Winner(s):', value: `none` },
 									{ name: '💝 People Entered', value: `***${winnnerNumber}***` }
 								)
-								.setFooter('Giveaway Ended.')
+								.setFooter({ text: 'Giveaway Ended.' })
 
 							button.message.edit({ embeds: [embedod], components: [] })
 						} else {
@@ -892,13 +892,13 @@ async function clickBtn(button, options = []) {
 									{ name: '🏆 Winner(s):', value: `${winner}` },
 									{ name: '💝 People Entered', value: `***${entero}***` }
 								)
-								.setFooter('Giveaway Ended.')
+								.setFooter({ text: 'Giveaway Ended.' })
 
 							const embb = new Discord.MessageEmbed()
 								.setColor(0x3bb143)
 								.setTitle('You just won the giveaway.')
 								.setDescription(`🏆 Winner(s): ***${winnerNumber}***`)
-								.setFooter('Dm the host to claim your prize 0_0')
+								.setFooter({ text: 'Dm the host to claim your prize 0_0' })
 
 							const gothere = new Discord.MessageButton()
 								.setLabel('View Giveaway')

--- a/src/embed.js
+++ b/src/embed.js
@@ -114,7 +114,7 @@ async function embed(message, options = []) {
 					'https://user-images.githubusercontent.com/71836991/145395922-311bb29a-a45b-476a-b55e-73cd4717f401.png'
 				)
 				.setColor(options.embedColor || '#075FFF')
-				.setFooter(foot)
+				.setFooter({ text: foot })
 
 			let e
 			if (message.commandId) {
@@ -129,7 +129,7 @@ async function embed(message, options = []) {
 				})
 			}
 
-			const emb = new MessageEmbed().setFooter(foot).setColor('#2F3136')
+			const emb = new MessageEmbed().setFooter({ text: foot }).setColor('#2F3136')
 
 			message.channel
 				.send({ content: '** **', embeds: [emb] })
@@ -247,7 +247,7 @@ async function embed(message, options = []) {
 										.setTitle(membed.embeds[0].title || '')
 										.setDescription(membed.embeds[0].description || '')
 										.setColor(membed.embeds[0].color || '#36393F')
-										.setFooter(membed.embeds[0].footer.text || '')
+										.setFooter({ text: membed.embeds[0].footer.text || '' })
 										.setImage(url)
 										.setURL(membed.embeds[0].url || '')
 										.setThumbnail(
@@ -287,7 +287,7 @@ async function embed(message, options = []) {
 										.setTitle(membed.embeds[0].title || '')
 										.setDescription(membed.embeds[0].description || '')
 										.setColor(membed.embeds[0].color || '#36393F')
-										.setFooter(membed.embeds[0].footer.text || '')
+										.setFooter({ text: membed.embeds[0].footer.text || '' })
 										.setImage(url)
 										.setURL(membed.embeds[0].url || '')
 										.setThumbnail(
@@ -381,7 +381,7 @@ async function embed(message, options = []) {
 											.setTitle(membed.embeds[0].title || '')
 											.setDescription(membed.embeds[0].description || '')
 											.setColor(membed.embeds[0].color || '#36393F')
-											.setFooter(membed.embeds[0].footer.text || '')
+											.setFooter({ text: membed.embeds[0].footer.text || '' })
 											.setImage(url)
 											.setURL(membed.embeds[0].url || '')
 											.setThumbnail(
@@ -446,7 +446,7 @@ async function embed(message, options = []) {
 											.setTitle(membed.embeds[0].title || '')
 											.setDescription(membed.embeds[0].description || '')
 											.setColor(membed.embeds[0].color || '#36393F')
-											.setFooter(membed.embeds[0].footer.text || '')
+											.setFooter({ text: membed.embeds[0].footer.text || '' })
 											.setImage(url)
 											.setURL(membed.embeds[0].url || '')
 											.setThumbnail(
@@ -504,7 +504,7 @@ async function embed(message, options = []) {
 												.setTitle(membed.embeds[0].title || '')
 												.setDescription(membed.embeds[0].description || '')
 												.setColor(membed.embeds[0].color || '#36393F')
-												.setFooter(membed.embeds[0].footer.text || '')
+												.setFooter({ text: membed.embeds[0].footer.text || '' })
 												.setImage(url)
 												.setURL(membed.embeds[0].url || '')
 												.setThumbnail(
@@ -559,7 +559,7 @@ async function embed(message, options = []) {
 									.setTitle(membed.embeds[0].title || '')
 									.setDescription(membed.embeds[0].description || '')
 									.setColor(membed.embeds[0].color || '#36393F')
-									.setFooter(membed.embeds[0].footer.text || '')
+									.setFooter({ text: membed.embeds[0].footer.text || '' })
 									.setImage(url)
 									.setURL(membed.embeds[0].url || '')
 									.setThumbnail(
@@ -625,7 +625,7 @@ async function embed(message, options = []) {
 									.setDescription(membed.embeds[0].description || '')
 									.setColor(membed.embeds[0].color || '#2F3136')
 									.setURL(membed.embeds[0].url || '')
-									.setFooter(membed.embeds[0].footer.text || '')
+									.setFooter({ text: membed.embeds[0].footer.text || '' })
 									.setImage(url)
 									.setThumbnail(m.content || m.attachments.first().url || '')
 									.setAuthor(
@@ -672,7 +672,7 @@ async function embed(message, options = []) {
 										.setDescription(membed.embeds[0].description || '')
 										.setColor(`${m.content}`)
 										.setURL(membed.embeds[0].url || '')
-										.setFooter(membed.embeds[0].footer.text || '')
+										.setFooter({ text: membed.embeds[0].footer.text || '' })
 										.setImage(url)
 										.setAuthor(
 											membed.embeds[0].author?.name
@@ -748,7 +748,7 @@ async function embed(message, options = []) {
 										.setDescription(membed.embeds[0].description || '')
 										.setColor(membed.embeds[0].color || '#2F3136')
 										.setImage(url || '')
-										.setFooter(membed.embeds[0].footer.text || '')
+										.setFooter({ text: membed.embeds[0].footer.text || '' })
 										.setThumbnail(
 											membed.embeds[0].thumbnail
 												? membed.embeds[0].thumbnail.url
@@ -792,7 +792,7 @@ async function embed(message, options = []) {
 									.setTitle(membed.embeds[0].title || '')
 									.setDescription(membed.embeds[0].description || '')
 									.setColor(membed.embeds[0].color || '#2F3136')
-									.setFooter(membed.embeds[0].footer.text || '')
+									.setFooter({ text: membed.embeds[0].footer.text || '' })
 									.setAuthor(
 										membed.embeds[0].author?.name
 											? membed.embeds[0].author?.name
@@ -860,7 +860,7 @@ async function embed(message, options = []) {
 									)
 									.setTimestamp(membed.embeds[0].timestamp ? new Date() : false)
 									.setImage(url || '')
-									.setFooter(membed.embeds[0].footer.text || '')
+									.setFooter({ text: membed.embeds[0].footer.text || '' })
 								m.delete().catch(() => {})
 								titleclr.stop()
 
@@ -910,7 +910,7 @@ async function embed(message, options = []) {
 									)
 									.setColor(membed.embeds[0].color || '#2F3136')
 									.setImage(url || '')
-									.setFooter(membed.embeds[0].footer.text || '')
+									.setFooter({ text: membed.embeds[0].footer.text || '' })
 								m.delete().catch(() => {})
 								titleclr.stop()
 								membed
@@ -947,7 +947,7 @@ async function embed(message, options = []) {
 									)
 									.setDescription(membed.embeds[0].description || '')
 									.setColor(membed.embeds[0].color || '#2F3136')
-									.setFooter(m.content || '')
+									.setFooter({ text: m.content || '' })
 									.setImage(url || '')
 									.setAuthor(
 										membed.embeds[0].author?.name

--- a/src/ghostPing.js
+++ b/src/ghostPing.js
@@ -45,7 +45,7 @@ async function ghostPing(message, options = []) {
 							})**\n\nContent: **${message.content}**`
 					)
 					.setColor(options.embedColor || 0x075fff)
-					.setFooter(foot)
+					.setFooter({ text: foot })
 					.setTimestamp()
 
 				message.channel

--- a/src/giveaway.js
+++ b/src/giveaway.js
@@ -77,10 +77,8 @@ async function giveawaySystem(client, db, message, options = []) {
 				.setTitle(options.embedTitle || 'Giveaways')
 				.setColor(0x075fff)
 				.setTimestamp(Number(Date.now() + ms(time)))
-				.setFooter(
-					'Ends ',
-					'https://media.discordapp.net/attachments/867344516600037396/881941206513377331/869185703228084285.gif'
-				)
+				.setFooter({ text: 'Ends ',
+				'https://media.discordapp.net/attachments/867344516600037396/881941206513377331/869185703228084285.gif' })
 				.setDescription(
 					`React with the buttons to interact with giveaway.\n\n**🎁 Prize:** ***${
 						options.prize || prize
@@ -124,7 +122,7 @@ async function giveawaySystem(client, db, message, options = []) {
 							.setDescription(
 								`Please wait.. We are Processing the winner with magiks`
 							)
-							.setFooter('Giveaway Ending.. Wait a moment.')
+							.setFooter({ text: 'Giveaway Ending.. Wait a moment.' })
 
 						m.edit({ embeds: [embeddd], components: [] })
 
@@ -147,7 +145,7 @@ async function giveawaySystem(client, db, message, options = []) {
 										{ name: '🏆 Winner(s):', value: `none` },
 										{ name: '💝 People Entered', value: `***0***` }
 									)
-									.setFooter('Giveaway Ended.')
+									.setFooter({ text: 'Giveaway Ended.' })
 
 								m.edit({ embeds: [embedod], components: [] })
 							} else {
@@ -210,13 +208,13 @@ async function giveawaySystem(client, db, message, options = []) {
 										{ name: '🏆 Winner(s):', value: `${winner}` },
 										{ name: '💝 People Entered', value: `***${entero}***` }
 									)
-									.setFooter('Giveaway Ended.')
+									.setFooter({ text: 'Giveaway Ended.' })
 
 								const embb = new Discord.MessageEmbed()
 									.setColor(0x3bb143)
 									.setTitle('You just won the giveaway.')
 									.setDescription(`🏆 Winner(s): ***${winnerNumber}***`)
-									.setFooter('Dm the host to claim your prize 0_0')
+									.setFooter({ text: 'Dm the host to claim your prize 0_0' })
 
 								const gothere = new Discord.MessageButton()
 									.setLabel('View Giveaway')
@@ -275,10 +273,10 @@ async function giveawaySystem(client, db, message, options = []) {
 								.setTitle(options.embedTitle || 'Giveaways')
 								.setColor(0x075fff)
 								.setTimestamp(Number(Date.now() + ms(time)))
-								.setFooter(
-									'Ends at ',
+								.setFooter({
+									text: 'Ends at ',
 									'https://media.discordapp.net/attachments/867344516600037396/881941206513377331/869185703228084285.gif'
-								)
+						})
 								.setDescription(
 									`React with the buttons to interact with giveaway.\n\n**🎁 Prize:** ***${
 										options.prize || prize
@@ -312,10 +310,10 @@ async function giveawaySystem(client, db, message, options = []) {
 								.setTitle(options.embedTitle || 'Giveaways')
 								.setColor(0x075fff)
 								.setTimestamp(Number(Date.now() + ms(time)))
-								.setFooter(
-									'Ends at ',
+								.setFooter({
+									text: 'Ends at ',
 									'https://media.discordapp.net/attachments/867344516600037396/881941206513377331/869185703228084285.gif'
-								)
+						})
 								.setDescription(
 									`React with the buttons to interact with giveaway.\n\n**🎁 Prize:** ***${
 										options.prize || prize
@@ -383,10 +381,10 @@ async function giveawaySystem(client, db, message, options = []) {
 				.setTitle(options.embedTitle || 'Giveaways')
 				.setColor(0x075fff)
 				.setTimestamp(Number(Date.now() + ms(time)))
-				.setFooter(
-					'Ends ',
+				.setFooter({
+					text: 'Ends ',
 					'https://media.discordapp.net/attachments/867344516600037396/881941206513377331/869185703228084285.gif'
-				)
+		})
 				.setDescription(
 					`React with the buttons to interact with giveaway.\n\n**🎁 Prize:** ***${
 						options.prize || prize
@@ -431,7 +429,7 @@ async function giveawaySystem(client, db, message, options = []) {
 							.setDescription(
 								`Please wait.. We are Processing the winner with magiks`
 							)
-							.setFooter('Giveaway Ending.. Wait a moment.')
+							.setFooter({ text: 'Giveaway Ending.. Wait a moment.' })
 
 						m.edit({ embeds: [embeddd], components: [] })
 
@@ -454,7 +452,7 @@ async function giveawaySystem(client, db, message, options = []) {
 										{ name: '🏆 Winner(s):', value: `none` },
 										{ name: '💝 People Entered', value: `***0***` }
 									)
-									.setFooter('Giveaway Ended.')
+									.setFooter({ text: 'Giveaway Ended.' })
 
 								m.edit({ embeds: [embedod], components: [] })
 							} else {
@@ -517,13 +515,13 @@ async function giveawaySystem(client, db, message, options = []) {
 										{ name: '🏆 Winner(s):', value: `${winner}` },
 										{ name: '💝 People Entered', value: `***${entero}***` }
 									)
-									.setFooter('Giveaway Ended.')
+									.setFooter({ text: 'Giveaway Ended.' })
 
 								const embb = new Discord.MessageEmbed()
 									.setColor(0x3bb143)
 									.setTitle('You just won the giveaway.')
 									.setDescription(`🏆 Winner(s): ***${winnerNumber}***`)
-									.setFooter('Dm the host to claim your prize 0_0')
+									.setFooter({ text: 'Dm the host to claim your prize 0_0' })
 
 								const gothere = new Discord.MessageButton()
 									.setLabel('View Giveaway')
@@ -581,10 +579,10 @@ async function giveawaySystem(client, db, message, options = []) {
 								.setTitle(options.embedTitle || 'Giveaways')
 								.setColor(0x075fff)
 								.setTimestamp(Number(Date.now() + ms(time)))
-								.setFooter(
-									'Ends at ',
+								.setFooter({
+									text: 'Ends at ',
 									'https://media.discordapp.net/attachments/867344516600037396/881941206513377331/869185703228084285.gif'
-								)
+						})
 								.setDescription(
 									`React with the buttons to interact with giveaway.\n\n**🎁 Prize:** ***${
 										options.prize || prize
@@ -618,10 +616,10 @@ async function giveawaySystem(client, db, message, options = []) {
 								.setTitle(options.embedTitle || 'Giveaways')
 								.setColor(0x075fff)
 								.setTimestamp(Number(Date.now() + ms(time)))
-								.setFooter(
-									'Ends at ',
+								.setFooter({
+									text: 'Ends at ',
 									'https://media.discordapp.net/attachments/867344516600037396/881941206513377331/869185703228084285.gif'
-								)
+						})
 								.setDescription(
 									`React with the buttons to interact with giveaway.\n\n**🎁 Prize:** ***${
 										options.prize || prize

--- a/src/modmail.js
+++ b/src/modmail.js
@@ -82,7 +82,7 @@ async function modmail(client, message, options = []) {
 					.setDescription(
 						`As this command is used in dms.. We dont know what guild you are trying to open the modmail. Please select the guild in the select menu`
 					)
-					.setFooter(foot)
+					.setFooter({ text: foot })
 					.setColor('#075FFF')
 
 				message.channel
@@ -245,7 +245,7 @@ async function modmail(client, message, options = []) {
 											.setDescription(
 												`***You have opened a modmail.***\nPlease wait for the *support team* to contact with you.\n***I will react to your message if it is delivered***`
 											)
-											.setFooter(foot)
+											.setFooter({ text: foot })
 											.setColor('#075FFF')
 
 										message.author
@@ -279,7 +279,7 @@ async function modmail(client, message, options = []) {
 															)
 															.setTimestamp()
 															.setColor('#c90000')
-															.setFooter(foot)
+															.setFooter({ text: foot })
 
 														button
 															.reply({
@@ -306,7 +306,7 @@ async function modmail(client, message, options = []) {
 																			)
 																			.setTimestamp()
 																			.setColor('#c90000')
-																			.setFooter(foot)
+																			.setFooter({ text: foot })
 
 																		setTimeout(() => {
 																			message.author.send({ embeds: [embaaa] })
@@ -400,7 +400,7 @@ async function modmail(client, message, options = []) {
 											.setThumbnail(guild.iconURL())
 											.setTimestamp()
 											.setColor(options.embedColor || '#075FFF')
-											.setFooter(foot)
+											.setFooter({ text: foot })
 
 										let pingrole = []
 										if (options.pingRole) {
@@ -530,7 +530,7 @@ async function modmail(client, message, options = []) {
 														)
 														.setTimestamp()
 														.setColor('#c90000')
-														.setFooter(foot)
+														.setFooter({ text: foot })
 
 													button
 														.reply({
@@ -557,7 +557,7 @@ async function modmail(client, message, options = []) {
 																		)
 																		.setTimestamp()
 																		.setColor('#c90000')
-																		.setFooter(foot)
+																		.setFooter({ text: foot })
 
 																	setTimeout(() => {
 																		message.author.send({ embeds: [embaaa] })
@@ -610,7 +610,7 @@ async function modmail(client, message, options = []) {
 													msg.author.displayAvatarURL()
 												)
 												.setDescription(msg.content)
-												.setFooter(foot)
+												.setFooter({ text: foot })
 												.setImage(
 													msg.attachments.first()
 														? msg.attachments.first().url
@@ -640,7 +640,7 @@ async function modmail(client, message, options = []) {
 				.setDescription(
 					`***You have opened a modmail.***\nPlease wait for the *support team* to contact with you.\n***I will react to your message if it is delivered***`
 				)
-				.setFooter(foot)
+				.setFooter({ text: foot })
 				.setColor('#075FFF')
 
 			let nopeembed = new Discord.MessageEmbed()
@@ -648,7 +648,7 @@ async function modmail(client, message, options = []) {
 				.setDescription(
 					`Sorry but your ***dms are closed.*** You should **open your dms** to contact with the support team.`
 				)
-				.setFooter(foot)
+				.setFooter({ text: foot })
 				.setColor('#cc0000')
 
 			if (options.blacklistUser) {
@@ -728,7 +728,7 @@ async function modmail(client, message, options = []) {
 										message.author.displayAvatarURL()
 									)
 									.setDescription(msg.content)
-									.setFooter(foot)
+									.setFooter({ text: foot })
 									.setImage(
 										msg.attachments.first() ? msg.attachments.first().url : ''
 									)
@@ -758,7 +758,7 @@ async function modmail(client, message, options = []) {
 						.setThumbnail(message.guild.iconURL())
 						.setTimestamp()
 						.setColor(options.embedColor || '#075FFF')
-						.setFooter(foot)
+						.setFooter({ text: foot })
 
 					let supportRole =
 						message.guild.roles.cache.get(options.role) || '***Support Team***'
@@ -795,7 +795,7 @@ async function modmail(client, message, options = []) {
 									)
 									.setTimestamp()
 									.setColor('#c90000')
-									.setFooter(foot)
+									.setFooter({ text: foot })
 
 								button
 									.reply({
@@ -821,7 +821,7 @@ async function modmail(client, message, options = []) {
 													)
 													.setTimestamp()
 													.setColor('#c90000')
-													.setFooter(foot)
+													.setFooter({ text: foot })
 
 												setTimeout(() => {
 													message.author.send({ embeds: [embaaa] })
@@ -871,7 +871,7 @@ async function modmail(client, message, options = []) {
 						let tosupport = new Discord.MessageEmbed()
 							.setAuthor(msg.author.tag, msg.author.displayAvatarURL())
 							.setDescription(msg.content)
-							.setFooter(foot)
+							.setFooter({ text: foot })
 							.setImage(
 								msg.attachments.first() ? msg.attachments.first().url : ''
 							)

--- a/src/rps.js
+++ b/src/rps.js
@@ -104,7 +104,7 @@ async function rps(msgOrInter, options = {}) {
 			.setTitle('Game Timed Out!')
 			.setColor(options.timeoutEmbedColor)
 			.setDescription('One or more players did not make a move in time(30s)')
-			.setFooter(foot)
+			.setFooter({ text: foot })
 
 		try {
 			let opponent
@@ -149,7 +149,7 @@ async function rps(msgOrInter, options = {}) {
 					(interaction ? interaction.user : message.author).displayAvatarURL()
 				)
 				.setColor(options.embedColor)
-				.setFooter(foot)
+				.setFooter({ text: foot })
 
 			/** @type {Discord.Message} */
 			let m
@@ -193,7 +193,7 @@ async function rps(msgOrInter, options = {}) {
 						}`
 					)
 					.setColor(options.embedColor)
-					.setFooter(foot)
+					.setFooter({ text: foot })
 					.setDescription('Select 🪨, 📄, or ✂️')
 
 				if (msgOrInter.commandId) {
@@ -276,7 +276,7 @@ async function rps(msgOrInter, options = {}) {
 											.setTitle('Draw!')
 											.setColor(options.drawEmbedColor)
 											.setDescription(`Both players chose **${op}**`)
-											.setFooter(foot)
+											.setFooter({ text: foot })
 									],
 									components: []
 								})
@@ -289,7 +289,7 @@ async function rps(msgOrInter, options = {}) {
 											.setTitle('Draw!')
 											.setColor(options.drawEmbedColor)
 											.setDescription(`Both players chose **${op}**`)
-											.setFooter(foot)
+											.setFooter({ text: foot })
 									],
 									components: []
 								})
@@ -312,7 +312,7 @@ async function rps(msgOrInter, options = {}) {
 											.setTitle(`${opponent.tag} Wins!`)
 											.setColor(options.winEmbedColor)
 											.setDescription(`**${op}** defeats **${auth}**`)
-											.setFooter(foot)
+											.setFooter({ text: foot })
 									],
 									components: []
 								})
@@ -327,7 +327,7 @@ async function rps(msgOrInter, options = {}) {
 											.setTitle(`${opponent.tag} Wins!`)
 											.setColor(options.winEmbedColor)
 											.setDescription(`**${op}** defeats **${auth}**`)
-											.setFooter(foot)
+											.setFooter({ text: foot })
 									],
 									components: []
 								})
@@ -354,7 +354,7 @@ async function rps(msgOrInter, options = {}) {
 											)
 											.setColor(options.winEmbedColor)
 											.setDescription(`**${auth}** defeats **${op}**`)
-											.setFooter(foot)
+											.setFooter({ text: foot })
 									],
 									components: []
 								})
@@ -370,7 +370,7 @@ async function rps(msgOrInter, options = {}) {
 											)
 											.setColor(options.winEmbedColor)
 											.setDescription(`**${auth}** defeats **${op}**`)
-											.setFooter(foot)
+											.setFooter({ text: foot })
 									],
 									components: []
 								})
@@ -395,7 +395,7 @@ async function rps(msgOrInter, options = {}) {
 										interaction.user.displayAvatarURL()
 									)
 									.setColor(options.timeoutEmbedColor)
-									.setFooter(foot)
+									.setFooter({ text: foot })
 									.setDescription('Ran out of time!\nTime limit: 30s')
 							],
 							components: []
@@ -411,7 +411,7 @@ async function rps(msgOrInter, options = {}) {
 										message.author.displayAvatarURL()
 									)
 									.setColor(options.timeoutEmbedColor)
-									.setFooter(foot)
+									.setFooter({ text: foot })
 									.setDescription('Ran out of time!\nTime limit: 30s')
 							],
 							components: []
@@ -429,7 +429,7 @@ async function rps(msgOrInter, options = {}) {
 										interaction.user.displayAvatarURL()
 									)
 									.setColor(options.timeoutEmbedColor || 0xc90000)
-									.setFooter(foot)
+									.setFooter({ text: foot })
 									.setDescription(`${opponent.tag} has declined your game!`)
 							],
 							components: []
@@ -445,7 +445,7 @@ async function rps(msgOrInter, options = {}) {
 										message.author.displayAvatarURL()
 									)
 									.setColor(options.timeoutEmbedColor || 0xc90000)
-									.setFooter(foot)
+									.setFooter({ text: foot })
 									.setDescription(`${opponent.tag} has declined your game!`)
 							],
 							components: []

--- a/src/starboard.js
+++ b/src/starboard.js
@@ -68,7 +68,7 @@ async function starboard(client, reaction, options = []) {
 					.setTitle(`Jump to message`)
 					.setURL(fetchMsg.url)
 					.setImage(url)
-					.setFooter('⭐ | ID: ' + fetchMsg.id)
+					.setFooter({ text: '⭐ | ID: ' + fetchMsg.id })
 
 				const msgs = await starboard.messages.fetch({ limit: 100 })
 
@@ -139,7 +139,7 @@ async function starboard(client, reaction, options = []) {
 					.setTitle(`Jump to message`)
 					.setURL(fetchMsg.url)
 					.setImage(url)
-					.setFooter('⭐ | ID: ' + fetchMsg.id)
+					.setFooter({ text: '⭐ | ID: ' + fetchMsg.id })
 
 				const msgs = await starboard.messages.fetch({ limit: 100 })
 

--- a/src/stealEmoji.js
+++ b/src/stealEmoji.js
@@ -52,7 +52,7 @@ async function stealEmoji(message, args, options = []) {
 							)
 							.setThumbnail(url)
 							.setColor(options.embedColor || 0x075fff)
-							.setFooter(foot)
+							.setFooter({ text: foot })
 
 						message.channel.send({ embeds: [mentionav] })
 					})
@@ -92,7 +92,7 @@ async function stealEmoji(message, args, options = []) {
 								)
 								.setThumbnail(url)
 								.setColor(options.embedColor || 0x075fff)
-								.setFooter(foot)
+								.setFooter({ text: foot })
 
 							message.channel.send({ embeds: [mentionav] })
 						})
@@ -124,7 +124,7 @@ async function stealEmoji(message, args, options = []) {
 								)
 								.setThumbnail(url)
 								.setColor(options.embedColor || 0x075fff)
-								.setFooter(foot)
+								.setFooter({ text: foot })
 
 							message.channel.send({ embeds: [mentionav] })
 						})
@@ -146,7 +146,7 @@ async function stealEmoji(message, args, options = []) {
 					)
 					.setThumbnail(uri)
 					.setColor(0xc90000)
-					.setFooter(foot)
+					.setFooter({ text: foot })
 
 				message.channel.send({ embeds: [mentionav] })
 			} else {
@@ -172,7 +172,7 @@ async function stealEmoji(message, args, options = []) {
 							)
 							.setThumbnail(url)
 							.setColor(options.embedColor || 0x075fff)
-							.setFooter(foot)
+							.setFooter({ text: foot })
 
 						message.channel.send({ embeds: [mentionav] })
 					})

--- a/src/stealSticker.js
+++ b/src/stealSticker.js
@@ -53,7 +53,7 @@ async function stealSticker(message, args, options = []) {
 							)
 							.setThumbnail(st.url)
 							.setColor(options.embedColor || 0x075fff)
-							.setFooter(foot)
+							.setFooter({ text: foot })
 
 						message.channel.send({ embeds: [mentionav] })
 						message.delete()
@@ -72,7 +72,7 @@ async function stealSticker(message, args, options = []) {
 							)
 							.setThumbnail(st.url)
 							.setColor(options.embedColor || 0x075fff)
-							.setFooter(foot)
+							.setFooter({ text: foot })
 
 						message.channel.send({ embeds: [mentionav] })
 						message.delete()

--- a/src/suggestBtn.js
+++ b/src/suggestBtn.js
@@ -373,7 +373,7 @@ async function suggestBtn(button, users, options = []) {
 					.setDescription(oldemb.description)
 					.setColor(oldemb.color)
 					.setAuthor(oldemb.author.name, oldemb.author.iconURL)
-					.setFooter(oldemb.footer.text)
+					.setFooter({ text: oldemb.footer.text })
 					.setImage(oldemb.image)
 					.addFields(
 						{ name: oldemb.fields[0].name, value: oldemb.fields[0].value },
@@ -411,7 +411,7 @@ async function suggestBtn(button, users, options = []) {
 					.setColor(oldemb.color)
 					.setAuthor(oldemb.author.name, oldemb.author.iconURL)
 					.setImage(oldemb.image)
-					.setFooter(oldemb.footer.text)
+					.setFooter({ text: oldemb.footer.text })
 					.addFields(
 						{ name: oldemb.fields[0].name, value: oldemb.fields[0].value },
 						{
@@ -448,7 +448,7 @@ async function suggestBtn(button, users, options = []) {
 					.setColor(options.denyEmbColor || 'RED')
 					.setAuthor(oldemb.author.name, oldemb.author.iconURL)
 					.setImage(oldemb.image)
-					.setFooter(`Rejected by ${user.tag}`)
+					.setFooter({ text: `Rejected by ${user.tag}` })
 					.addFields(
 						{ name: 'Status:', value: `\`\`\`Rejected !\`\`\`` },
 						{ name: 'Reason:', value: `\`\`\`${reason}\`\`\`` },
@@ -489,7 +489,7 @@ async function suggestBtn(button, users, options = []) {
 					.setColor(oldemb.color)
 					.setAuthor(oldemb.author.name, oldemb.author.iconURL)
 					.setImage(oldemb.image)
-					.setFooter(oldemb.footer.text)
+					.setFooter({ text: oldemb.footer.text })
 					.addFields(
 						{ name: oldemb.fields[0].name, value: oldemb.fields[0].value },
 						{
@@ -526,7 +526,7 @@ async function suggestBtn(button, users, options = []) {
 					.setColor(oldemb.color)
 					.setAuthor(oldemb.author.name, oldemb.author.iconURL)
 					.setImage(oldemb.image)
-					.setFooter(oldemb.footer.text)
+					.setFooter({ text: oldemb.footer.text })
 					.addFields(
 						{ name: oldemb.fields[0].name, value: oldemb.fields[0].value },
 						{
@@ -563,7 +563,7 @@ async function suggestBtn(button, users, options = []) {
 					.setColor(options.agreeEmbColor || 'GREEN')
 					.setAuthor(oldemb.author.name, oldemb.author.iconURL)
 					.setImage(oldemb.image)
-					.setFooter(`Accepted by ${user.tag}`)
+					.setFooter({ text: `Accepted by ${user.tag}` })
 					.addFields(
 						{ name: 'Status:', value: `\`\`\`Accepted !\`\`\`` },
 						{ name: 'Reason:', value: `\`\`\`${reason}\`\`\`` },

--- a/src/suggestSystem.js
+++ b/src/suggestSystem.js
@@ -74,7 +74,7 @@ async function suggestSystem(client, message, args, options = []) {
 				.setDescription(`Is this your suggestion ? \`${suggestion}\``)
 				.setTimestamp()
 				.setColor(options.embedColor || '#075FFF')
-				.setFooter(foot)
+				.setFooter({ text: foot })
 
 			interaction
 				.followUp({ embeds: [embedo], components: [row1], ephemeral: true })
@@ -99,7 +99,7 @@ async function suggestSystem(client, message, args, options = []) {
 									interaction.user.displayAvatarURL()
 								)
 								.setColor(options.embedColor || '#075FFF')
-								.setFooter(foot)
+								.setFooter({ text: foot })
 								.addFields(
 									{
 										name: 'Status:',
@@ -183,7 +183,7 @@ async function suggestSystem(client, message, args, options = []) {
 				.setTimestamp()
 				.setImage(url)
 				.setColor(options.embedColor || '#075FFF')
-				.setFooter(foot)
+				.setFooter({ text: foot })
 
 			message.channel
 				.send({ embeds: [embedo], components: [row1] })
@@ -215,7 +215,7 @@ async function suggestSystem(client, message, args, options = []) {
 									message.author.displayAvatarURL()
 								)
 								.setColor(options.embedColor || '#075FFF')
-								.setFooter(foot)
+								.setFooter({ text: foot })
 								.setImage(url)
 								.addFields(
 									{

--- a/src/ticketSystem.js
+++ b/src/ticketSystem.js
@@ -69,7 +69,7 @@ async function ticketSystem(message, channel, options = []) {
 			.setThumbnail(message.guild.iconURL())
 			.setTimestamp()
 			.setColor(options.embedColor || '#075FFF')
-			.setFooter(foot)
+			.setFooter({ text: foot })
 
 		try {
 			if (message.commandId) {

--- a/src/tictactoe.js
+++ b/src/tictactoe.js
@@ -84,7 +84,7 @@ async function tictactoe(message, options = []) {
 					(message.user ? message.user : message.author).displayAvatarURL()
 				)
 				.setColor(options.embedColor || 0x075fff)
-				.setFooter(foot)
+				.setFooter({ text: foot })
 
 			let accept = new Discord.MessageButton()
 				.setLabel('Accept')
@@ -199,7 +199,7 @@ async function tictactoe(message, options = []) {
 					let epm = new Discord.MessageEmbed()
 						.setTitle('TicTacToe..')
 						.setColor(options.embedColor || 0x075fff)
-						.setFooter(foot)
+						.setFooter({ text: foot })
 						.setTimestamp()
 
 					let msg
@@ -830,7 +830,7 @@ async function tictactoe(message, options = []) {
 							(message.user ? message.user : message.author).displayAvatarURL()
 						)
 						.setColor(options.timeoutEmbedColor || 0xc90000)
-						.setFooter(foot)
+						.setFooter({ text: foot })
 						.setDescription('Ran out of time!\nTime limit: 30s')
 					m.edit({
 						content: '<@' + opponent.id + '>. Didnt accept in time',
@@ -846,7 +846,7 @@ async function tictactoe(message, options = []) {
 							(message.user ? message.user : message.author).displayAvatarURL()
 						)
 						.setColor(options.timeoutEmbedColor || 0xc90000)
-						.setFooter(foot)
+						.setFooter({ text: foot })
 						.setDescription(`${opponent.user.tag} has declined your game!`)
 					m.edit({
 						embeds: [embed],


### PR DESCRIPTION
# Information
All of the `.setFooter()` `Discord#MessageEmbed` options will include the `{ text: }` parameter after all the commits because this package uses the deprecated version of `.setFooter()` without the text param

# Issue Related
The issue is that the `.setFooter()` option without the text parameter is getting deprecated and so this PR will fix that by passing the text param to every single file that uses `.setFooter()`

# Checks
The package works as intended and no deprecation errors are thrown.